### PR TITLE
Fix WebSocket stability, add TLS support, improve error handling

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -86,9 +86,9 @@ export function getActions(self) {
 				{
 					id: 'level',
 					type: 'number',
-					label: 'Master Intensity  (0-1)',
+					label: 'Master Intensity (0-100)',
 					default: 0,
-					max: 1,
+					max: 100,
 					min: 0,
 				},
 				{

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -1,9 +1,10 @@
 {
+	"$schema": "../node_modules/@companion-module/base/assets/manifest.schema.json",
 	"id": "pharos-designer",
 	"name": "pharos-designer",
 	"shortname": "designer",
 	"description": "Control Pharos Designer controllers via HTTP and WebSocket APIs with real-time feedback",
-	"version": "1.2.0",
+	"version": "0.0.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-pharos-designer.git",
 	"bugs": "https://github.com/bitfocus/companion-module-pharos-designer/issues",

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -34,24 +34,11 @@ export function getFeedbacks(self) {
 					required: true,
 				},
 			],
-			callback: async (feedback) => {
-				try {
-					if (!feedback.options.timeline) return false
-					// Use cached state from WebSocket if available
-					const cached = self.state?.timelines?.get(Number(feedback.options.timeline))
-					if (cached) {
-						return feedback.options.state === cached.state
-					}
-					// Fall back to HTTP polling if no cache
-					if (!self.controller) return false
-					const res = await self.controller.getTimelines()
-					const timeline = res.timelines.filter((timeline) => timeline.num == feedback.options.timeline)
-					if (!timeline.length) return false
-					return feedback.options.state === timeline[0].state
-				} catch (e) {
-					self.log('error', `timelineState feedback error: ${e.message}`)
-					return false
-				}
+			callback: (feedback) => {
+				if (!feedback.options.timeline) return false
+				const cached = self.state?.timelines?.get(Number(feedback.options.timeline))
+				if (!cached) return false
+				return feedback.options.state === cached.state
 			},
 		},
 		sceneState: {
@@ -82,24 +69,11 @@ export function getFeedbacks(self) {
 					required: true,
 				},
 			],
-			callback: async (feedback) => {
-				try {
-					if (!feedback.options.state || !feedback.options.scene) return false
-					// Use cached state from WebSocket if available
-					const cached = self.state?.scenes?.get(Number(feedback.options.scene))
-					if (cached) {
-						return feedback.options.state === cached.state
-					}
-					// Fall back to HTTP polling if no cache
-					if (!self.controller) return false
-					const res = await self.controller.getScenes()
-					const scene = res.scenes.filter((scene) => scene.num == feedback.options.scene)
-					if (!scene.length) return false
-					return feedback.options.state === scene[0].state
-				} catch (e) {
-					self.log('error', `sceneState feedback error: ${e.message}`)
-					return false
-				}
+			callback: (feedback) => {
+				if (!feedback.options.state || !feedback.options.scene) return false
+				const cached = self.state?.scenes?.get(Number(feedback.options.scene))
+				if (!cached) return false
+				return feedback.options.state === cached.state
 			},
 		},
 		groupState: {
@@ -138,40 +112,19 @@ export function getFeedbacks(self) {
 					required: true,
 				},
 			],
-			callback: async (feedback) => {
-				try {
-					if (feedback.options.level == null || !feedback.options.operation || !feedback.options.group) return false
-					// Use cached state from WebSocket if available
-					const cached = self.state?.groups?.get(Number(feedback.options.group))
-					if (cached) {
-						switch (feedback.options.operation) {
-							case 'more':
-								return cached.level > feedback.options.level
-							case 'less':
-								return cached.level < feedback.options.level
-							case 'equal':
-								return cached.level === feedback.options.level
-						}
-						return false
-					}
-					// Fall back to HTTP polling if no cache
-					if (!self.controller) return false
-					const res = await self.controller.getGroups()
-					const group = res.groups.filter((group) => group.num == feedback.options.group)
-					if (!group.length) return false
-					switch (feedback.options.operation) {
-						case 'more':
-							return group[0].level > feedback.options.level
-						case 'less':
-							return group[0].level < feedback.options.level
-						case 'equal':
-							return group[0].level === feedback.options.level
-					}
-					return false
-				} catch (e) {
-					self.log('error', `groupState feedback error: ${e.message}`)
-					return false
+			callback: (feedback) => {
+				if (feedback.options.level == null || !feedback.options.operation || !feedback.options.group) return false
+				const cached = self.state?.groups?.get(Number(feedback.options.group))
+				if (!cached) return false
+				switch (feedback.options.operation) {
+					case 'more':
+						return cached.level > feedback.options.level
+					case 'less':
+						return cached.level < feedback.options.level
+					case 'equal':
+						return cached.level === feedback.options.level
 				}
+				return false
 			},
 		},
 		inputState: {

--- a/main.js
+++ b/main.js
@@ -342,7 +342,14 @@ class PharosInstance extends InstanceBase {
 			const res = await fetch(`http://${this.config.host}${endpoint}`, {
 				headers: { Authorization: `Bearer ${this.controller.token}` },
 			})
-			if (!res.ok) return null
+			if (res.status === 401) {
+				this.log('warn', `HTTP 401 Unauthorized on ${endpoint} — token may be stale`)
+				return null
+			}
+			if (!res.ok) {
+				this.log('debug', `HTTP ${res.status} on ${endpoint}`)
+				return null
+			}
 			return await res.json()
 		} catch (e) {
 			this.log('debug', `Failed to fetch ${endpoint}: ${e.message}`)

--- a/main.js
+++ b/main.js
@@ -322,7 +322,11 @@ class PharosInstance extends InstanceBase {
 		if (interval <= 0) return
 		this.log('debug', `Input polling every ${interval}s`)
 		this.inputPollTimer = setInterval(() => {
-			this.refreshInputs()
+			if (this._inputPollInFlight) return
+			this._inputPollInFlight = true
+			this.refreshInputs().finally(() => {
+				this._inputPollInFlight = false
+			})
 		}, interval * 1000)
 	}
 

--- a/main.js
+++ b/main.js
@@ -291,7 +291,7 @@ class PharosInstance extends InstanceBase {
 			values[`remote_device_${num}_type`] = dev.type
 		}
 		values['beacon'] = this.state.beacon ? 'On' : 'Off'
-		values['ws_connected'] = String(!!this.pharosWs)
+		values['ws_connected'] = 'false'
 		this.setVariableValues(values)
 	}
 

--- a/main.js
+++ b/main.js
@@ -75,7 +75,7 @@ class PharosInstance extends InstanceBase {
 				if (self.lastStatus != InstanceStatus.UnknownError) {
 					self.updateStatus(InstanceStatus.UnknownError, 'Network error')
 					self.lastStatus = InstanceStatus.UnknownError
-					self.log('error', 'A network error occured while trying to authenticate')
+					self.log('error', 'A network error occurred while trying to authenticate')
 				}
 				this.pharosConnected = false
 			} else if (authRes.success) {
@@ -98,11 +98,7 @@ class PharosInstance extends InstanceBase {
 				) {
 					this.log('debug', 'Storing variables...')
 					// filter groups first because some dont have an id
-					this.filteredGroups = this.groupsResponse.groups.filter(function (group) {
-						if (group.num) {
-							return group
-						}
-					})
+					this.filteredGroups = this.groupsResponse.groups.filter((group) => !!group.num)
 					// mapping the data to select option arrays
 					this.actionData.groups = this.filteredGroups.map(function (group) {
 						return { id: group.num, label: group.name }
@@ -170,7 +166,7 @@ class PharosInstance extends InstanceBase {
 	}
 
 	async configUpdated(config) {
-		this.init(config)
+		await this.init(config)
 	}
 
 	// Return config fields for web config

--- a/main.js
+++ b/main.js
@@ -209,6 +209,14 @@ class PharosInstance extends InstanceBase {
 					'When enabled, the module maintains a WebSocket connection for real-time button feedback updates. Disable to use HTTP polling instead (for older firmware or limited connections — LPC supports 8, LPC X and VLC support 16).',
 			},
 			{
+				type: 'checkbox',
+				id: 'useSecureWebSocket',
+				label: 'Use secure WebSocket (wss://)',
+				width: 12,
+				default: false,
+				tooltip: 'Connect over wss:// (TLS) instead of ws://. Enable if your controller has HTTPS enabled (port 443).',
+			},
+			{
 				type: 'dropdown',
 				id: 'controllerLogLevel',
 				label: 'Controller log forwarding',

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"lint:raw": "eslint",
 		"lint": "yarn lint:raw .",
 		"build": "yarn companion-module-build --dev",
+		"package": "companion-module-build",
 		"postinstall": "husky"
 	},
 	"type": "module",
@@ -37,5 +38,9 @@
 			"prettier --write"
 		]
 	},
-	"prettier": "@companion-module/tools/.prettierrc.json"
+	"prettier": "@companion-module/tools/.prettierrc.json",
+	"engines": {
+		"node": ">=18.12"
+	},
+	"packageManager": "yarn@1.22.22"
 }

--- a/presets.js
+++ b/presets.js
@@ -372,13 +372,13 @@ export function getPresets(self) {
 
 	if (self.actionData.groups) {
 		const groupLevels = [
-			{ pct: 0, level: 0, label: '0%' },
-			{ pct: 15, level: 0.15, label: '15%' },
-			{ pct: 30, level: 0.3, label: '30%' },
-			{ pct: 50, level: 0.5, label: '50%' },
-			{ pct: 70, level: 0.7, label: '70%' },
-			{ pct: 85, level: 0.85, label: '85%' },
-			{ pct: 100, level: 1, label: '100%' },
+			{ pct: 0, label: '0%' },
+			{ pct: 15, label: '15%' },
+			{ pct: 30, label: '30%' },
+			{ pct: 50, label: '50%' },
+			{ pct: 70, label: '70%' },
+			{ pct: 85, label: '85%' },
+			{ pct: 100, label: '100%' },
 		]
 
 		for (const gr of self.actionData.groups) {
@@ -430,7 +430,7 @@ export function getPresets(self) {
 							down: [
 								{
 									actionId: 'controlGroups',
-									options: { num: gr.id, level: gl.level, fade: 0 },
+									options: { num: gr.id, level: gl.pct, fade: 0 },
 								},
 							],
 							up: [],

--- a/websocket.js
+++ b/websocket.js
@@ -18,7 +18,8 @@ export class PharosWebSocket {
 		this.host = host
 		this.token = token
 
-		const url = `ws://${host}/query`
+		const protocol = this.instance.config.useSecureWebSocket ? 'wss' : 'ws'
+		const url = `${protocol}://${host}/query`
 		this.instance.log('debug', `WebSocket connecting to ${url}`)
 
 		try {

--- a/websocket.js
+++ b/websocket.js
@@ -76,7 +76,11 @@ export class PharosWebSocket {
 
 	_send(obj) {
 		if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-			this.ws.send(JSON.stringify(obj))
+			try {
+				this.ws.send(JSON.stringify(obj))
+			} catch (e) {
+				this.instance.log('debug', 'WebSocket send failed: ' + e.message)
+			}
 		}
 	}
 

--- a/websocket.js
+++ b/websocket.js
@@ -115,7 +115,7 @@ export class PharosWebSocket {
 			this._handleBeaconBroadcast(msg.data)
 		} else if (msg.broadcast === 'remote_device') {
 			this._handleRemoteDeviceBroadcast(msg.data)
-		} else if (msg.request === 'log') {
+		} else if (msg.broadcast === 'log' || msg.request === 'log') {
 			this._handleLogMessage(msg.data)
 		}
 	}
@@ -216,27 +216,31 @@ export class PharosWebSocket {
 		// Parse log entries — each starts with \u0007
 		const entries = data.log.split('\u0007').filter((e) => e.length > 0)
 		for (const entry of entries) {
-			if (entry.length < 2) continue
-			const typeCode = entry.charCodeAt(0)
-			const levelCode = entry.charCodeAt(1)
+			try {
+				if (entry.length < 2) continue
+				const typeCode = entry.charCodeAt(0)
+				const levelCode = entry.charCodeAt(1)
 
-			// Filter by configured level
-			if (logLevel === 'warnings' && levelCode > 3) continue
+				// Filter by configured level
+				if (logLevel === 'warnings' && levelCode > 3) continue
 
-			const category = categoryNames[typeCode] || `Cat${typeCode}`
-			const level = levelNames[levelCode] || `Lvl${levelCode}`
+				const category = categoryNames[typeCode] || `Cat${typeCode}`
+				const level = levelNames[levelCode] || `Lvl${levelCode}`
 
-			// Extract message text — skip the offset (variable hex) and timestamp (8 hex chars)
-			// Find the first space after the offset+timestamp to get the message
-			const rest = entry.substring(2)
-			const spaceIdx = rest.indexOf(' ')
-			if (spaceIdx === -1) continue
-			const timestampAndMsg = rest.substring(spaceIdx + 1)
-			const msgSpaceIdx = timestampAndMsg.indexOf(' ')
-			const message = msgSpaceIdx !== -1 ? timestampAndMsg.substring(msgSpaceIdx + 1) : timestampAndMsg
+				// Extract message text — skip the offset (variable hex) and timestamp (8 hex chars)
+				// Find the first space after the offset+timestamp to get the message
+				const rest = entry.substring(2)
+				const spaceIdx = rest.indexOf(' ')
+				if (spaceIdx === -1) continue
+				const timestampAndMsg = rest.substring(spaceIdx + 1)
+				const msgSpaceIdx = timestampAndMsg.indexOf(' ')
+				const message = msgSpaceIdx !== -1 ? timestampAndMsg.substring(msgSpaceIdx + 1) : timestampAndMsg
 
-			const companionLevel = levelCode <= 3 ? 'warn' : 'debug'
-			this.instance.log(companionLevel, `[${category}/${level}] ${message.trim()}`)
+				const companionLevel = levelCode <= 3 ? 'warn' : 'debug'
+				this.instance.log(companionLevel, `[${category}/${level}] ${message.trim()}`)
+			} catch (e) {
+				this.instance.log('debug', `Log entry parse error: ${e.message}`)
+			}
 		}
 	}
 

--- a/websocket.js
+++ b/websocket.js
@@ -14,6 +14,7 @@ export class PharosWebSocket {
 
 	connect(host, token) {
 		if (this.destroyed) return
+		this._close() // Clean up any existing connection before creating a new one
 		this.host = host
 		this.token = token
 
@@ -28,7 +29,18 @@ export class PharosWebSocket {
 			return
 		}
 
+		// Connection timeout — if not connected within 10s, give up and reconnect
+		this._connectionTimeout = setTimeout(() => {
+			if (this.ws && this.ws.readyState !== WebSocket.OPEN) {
+				this.instance.log('warn', 'WebSocket connection timed out')
+				this._close()
+				this._scheduleReconnect()
+			}
+		}, 10000)
+
 		this.ws.on('open', () => {
+			clearTimeout(this._connectionTimeout)
+			this._connectionTimeout = null
 			this.instance.log('info', 'WebSocket connected')
 			this.reconnectDelay = 1000
 			this._subscribe('timeline')
@@ -269,6 +281,7 @@ export class PharosWebSocket {
 					this.instance.config.user,
 					this.instance.config.password,
 				)
+				if (this.destroyed) return // destroyed while awaiting auth
 				if (authRes.success) {
 					this.token = this.instance.controller.token
 					this.connect(this.host, this.token)
@@ -287,6 +300,8 @@ export class PharosWebSocket {
 
 	_close() {
 		this._stopKeepAlive()
+		clearTimeout(this._connectionTimeout)
+		this._connectionTimeout = null
 		if (this.ws) {
 			this.ws.removeAllListeners()
 			if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {


### PR DESCRIPTION
## Summary
Comprehensive fixes for WebSocket reliability, connection management, and HTTP error handling. Adds secure WebSocket (wss://) support and removes HTTP fallbacks from feedback callbacks.

## Key Changes

### WebSocket Improvements
- Add wss:// (TLS) support with new `useSecureWebSocket` config option (#18)
- Fix race conditions in connect/reconnect/destroy lifecycle (#10)
- Add connection timeout (10s) with automatic reconnect (#10)
- Wrap `_send()` in try-catch to handle send errors (#14)
- Improve log parser robustness with try-catch per entry (#20)
- Accept both `msg.broadcast` and `msg.request` for log messages (#20)

### Feedback & Action Fixes
- Remove HTTP fallback polling from feedback callbacks, use WebSocket cache only (#11)
- Fix group level range: 0-100 scale instead of 0-1 (#9)
- Simplify feedback callbacks — remove async/try-catch for cache-only lookups

### HTTP & Connection Management
- Distinguish 401 auth failures from other HTTP errors in `_fetchApi()` (#16)
- Add in-flight guard to input polling to prevent overlapping requests (#13)
- Seed `ws_connected` variable as 'false' before WebSocket handshake (#12)
- Clean up WebSocket connection on `_close()` before reconnecting (#10)

### Configuration & Standards
- Align manifest.json and package.json with Bitfocus conventions (#17)
- Add `$schema` reference to manifest.json
- Add engines constraint (Node >=18.12) and packageManager spec
- Add `package` script for production builds

### Minor Fixes
- Fix typo: "occured" → "occurred"
- Simplify group filtering with arrow function
- Await `configUpdated()` in init call (#3)
- Remove hardcoded level values from presets, use pct only (#9)